### PR TITLE
we need reduceReducers not combineReducers

### DIFF
--- a/src/modules/ethers-react-system/Context.js
+++ b/src/modules/ethers-react-system/Context.js
@@ -68,3 +68,42 @@ const Context = createContext({
 });
 
 export default Context;
+
+export const makeContext = (extensionsInitialState) =>
+  createContext({
+    instance: ethers,
+    address: undefined,
+    balance: undefined,
+    network: undefined,
+    nonce: undefined,
+    providers: undefined,
+    wallet: undefined,
+    contracts: {},
+    activity: {
+      deploy: {},
+      messages: {},
+      signatures: {},
+      transactions: {}
+    },
+    requests: {
+      deploy: [],
+      messages: [],
+      signatures: [],
+      transactions: []
+    },
+    library: {
+      contracts: []
+    },
+    store: {
+      contracts: []
+    },
+    enableRequest: () => { },
+    // contractDeployRequest: () => {},
+    // contractDeployFromBytecodeRequest: () => {},
+    // contractInitializeRequest: () => {},
+    // walletSendTransactionRequest: () => {},
+    // walletSignMessageRequest: () => {},
+    // walletSignMessageTypedRequest: () => {},
+    // walletSignTransactionRequest: () => {}
+    ...extensionsInitialState
+  })

--- a/src/modules/ethers-react-system/components/Provider.jsx
+++ b/src/modules/ethers-react-system/components/Provider.jsx
@@ -10,27 +10,29 @@
 import React, { useContext, useReducer } from "react";
 
 /* --- Local --- */
-import Context from "../Context";
+import Context, { makeContext } from "../Context";
 import reducers from "../reducer";
 import {
   combineReducers,
+  reduceReducers,
   enhanceActions,
   contractLoad,
-  extensionsInitialize
+  extensionsInitialize,
+  getExtensions
 } from "../middleware";
 
 /* --- Component --- */
 const Provider = ({ children, contracts = [], extensions }) => {
   // console.log(extensions, "extensions");
   /* --- Ethers Context --- */
-  const initialState = useContext(Context);
+  const {extensionsInitialState, extensionsReducers} = getExtensions(extensions);
+  const ctx = makeContext(extensionsInitialState)
+  const initialState = useContext(ctx);
 
+  const rootReducer = reduceReducers(initialState, reducers, ...Object.values(extensionsReducers))
   /* --- Reducer --- */
   const [state, dispatch] = useReducer(
-    // reducers,
-    combineReducers({
-      core: reducers
-    }),
+    rootReducer,
     initialState,
     contractLoad(contracts)
   );

--- a/src/modules/ethers-react-system/middleware/extensions.js
+++ b/src/modules/ethers-react-system/middleware/extensions.js
@@ -4,3 +4,24 @@ export const extensionsInitialize = (extensions, state, dispatch) =>
       effect(state, dispatch)
     );
   });
+
+const getExtensionsInitialState = (extensions) => extensions.map(({ name, initialState }) => {
+  return { name, initialState }
+}).reduce((acc, cur) => {
+  acc[cur.name] = cur.initialState;
+  return acc;
+}, {});
+
+const getExtensionsReducers = (extensions) => extensions.map(({ name, reducer }) => {
+  return { name, reducer }
+}).reduce((acc, cur) => {
+  acc[cur.name] = cur.reducer;
+  return acc;
+}, {});
+
+export const getExtensions = (extensions) => {
+  return {
+    extensionsInitialState: getExtensionsInitialState(extensions),
+    extensionsReducers: getExtensionsReducers(extensions)
+  }
+}

--- a/src/modules/ethers-react-system/middleware/index.js
+++ b/src/modules/ethers-react-system/middleware/index.js
@@ -1,4 +1,5 @@
 export { contractLoad } from "./initialize";
 export { combineReducers } from "./combineReducers";
+export { reduceReducers } from "./reduceReducers";
 export { enhanceActions } from "./actions";
-export { extensionsInitialize } from "./extensions";
+export { extensionsInitialize, getExtensions } from "./extensions";

--- a/src/modules/ethers-react-system/middleware/reduceReducers.js
+++ b/src/modules/ethers-react-system/middleware/reduceReducers.js
@@ -1,0 +1,29 @@
+export const reduceReducers = (...args) => {
+  const initialState = typeof args[0] !== 'function' && args.shift();
+  const reducers = args;
+
+  if (typeof initialState === 'undefined') {
+    throw new TypeError(
+      'The initial state may not be undefined. If you do not want to set a value for this reducer, you can use null instead of undefined.'
+    );
+  }
+
+  return (prevState, value, ...args) => {
+    const prevStateIsUndefined = typeof prevState === 'undefined';
+    const valueIsUndefined = typeof value === 'undefined';
+
+    if (prevStateIsUndefined && valueIsUndefined && initialState) {
+      return initialState;
+    }
+
+    return reducers.reduce((newState, reducer, index) => {
+      if (typeof reducer === 'undefined') {
+        throw new TypeError(
+          `An undefined reducer was passed in at index ${index}`
+        );
+      }
+
+      return reducer(newState, value, ...args);
+    }, prevStateIsUndefined && !valueIsUndefined && initialState ? initialState : prevState);
+  };
+};

--- a/src/providers.jsx
+++ b/src/providers.jsx
@@ -36,13 +36,17 @@ const contracts = [
 const extensions = [
   {
     name: "ethers-react-reactive",
-    hooks: hooksReactive
+    hooks: hooksReactive,
+    reducer: (state, action) => state,
+    initialState: {hello: 'world'}
   },
   {
     name: "ethers-react-global",
     actions: actionsGlobal,
     hooks: hooksGlobal,
-    types: typesGlobal
+    types: typesGlobal,
+    reducer: (state, action) => state,
+    initialState: {}
   }
 ];
 


### PR DESCRIPTION
Migrate from `combineReducers` to `reduceReducers`. This way all reducers are contained inside a single namespace.

Whereas `combineReducers` returns multiple namespaces by design...
![image](https://user-images.githubusercontent.com/182515/73595729-33e0e900-451c-11ea-8c93-40c8d45c401b.png)

`reduceReducers` merges the state into [one namespace](https://github.com/redux-utilities/reduce-reducers#usage).
![image](https://user-images.githubusercontent.com/182515/73595869-748d3200-451d-11ea-921b-f37ffce1f356.png)

The red arrows being the extensions that got passed into the Provider over in 
`<EthersProvider contracts={contracts} extensions={extensions}>`